### PR TITLE
Dev alpha - Improve Audio Stream Handling and Fix Resume Issues

### DIFF
--- a/word_activation_recognition/classify_audio.py
+++ b/word_activation_recognition/classify_audio.py
@@ -7,7 +7,7 @@ from time import sleep
 
 def activation_callback():
     print('Activation detected')
-    sleep(90)
+    sleep(20)
     print('Bye Bye !')
     exit(0)
 


### PR DESCRIPTION
Improved audio stream handling and resume fix

- Added `close_audio_stream` method to completely close the audio stream, releasing audio device resources.
- Modified `stop_listening` to call `close_audio_stream` and ensure the audio stream is stopped.
- Adjusted `resume_listening` to restart the audio stream by creating a new thread with the necessary arguments for audio classification.
- Added necessary arguments (`model`, `labels_file`, etc.) to the `__init__` constructor and stored these arguments in instance attributes for later use.
- Utilized stored arguments in `resume_listening` to correctly restart the thread when resuming listening.
- Improved process handling in `handle_results` to properly stop and restart the audio stream during keyword activation and assistant process execution.
- Fixed errors related to resuming listening after the assistant process completes.

These changes ensure effective management of audio device resources and correct issues with resuming listening after the assistant process execution.
